### PR TITLE
Decode the payload into a byte array to allow binary writing

### DIFF
--- a/gd-jpeg.py
+++ b/gd-jpeg.py
@@ -42,7 +42,7 @@ def inject_payload(jpeg, loc, payload, output):
     print("Injecting payload...")
     contents = f.read()
     pre_payload = contents[:loc + len(binascii.unhexlify(magic_number))]
-    post_payload = contents[loc + len(binascii.unhexlify(magic_number)) + len(payload):]
+    post_payload = contents[loc + len(binascii.unhexlify(magic_number)) + len(bin_payload):]
     fo.write(pre_payload + bin_payload + post_payload + bytes('\n', 'utf-8'))
     print("Payload written.")
 

--- a/gd-jpeg.py
+++ b/gd-jpeg.py
@@ -34,7 +34,7 @@ def get_loc(jpeg):
 
 def inject_payload(jpeg, loc, payload, output):
 
-    bin_payload = bin(int(binascii.hexlify(payload),16))
+    bin_payload = bytes(payload, 'utf-8')
 
     f = open(jpeg, 'rb')
     fo = open(output, 'wb')
@@ -43,7 +43,7 @@ def inject_payload(jpeg, loc, payload, output):
     contents = f.read()
     pre_payload = contents[:loc + len(binascii.unhexlify(magic_number))]
     post_payload = contents[loc + len(binascii.unhexlify(magic_number)) + len(payload):]
-    fo.write(pre_payload + payload + post_payload + '\n')
+    fo.write(pre_payload + bin_payload + post_payload + bytes('\n', 'utf-8'))
     print("Payload written.")
 
     f.close()


### PR DESCRIPTION
Convert all strings into byte arrays before concatenating them.
This should fix #3.