### PR TITLE
Read the payload from a file

### DIFF
--- a/gd-jpeg.py
+++ b/gd-jpeg.py
@@ -1,6 +1,7 @@
 #!/usr/bin/python
 import sys
 import binascii
+import os
 
 magic_number = "03010002110311003f00" 
 
@@ -15,7 +16,12 @@ def main():
     output = sys.argv[3]
 
     loc = get_loc(jpeg)
-    inject_payload(jpeg, loc, payload, output)
+
+    if os.path.exists(payload):
+        with open(payload, "r") as payload_file:
+            inject_payload(jpeg, loc, payload_file.read(), output)
+    else:
+        inject_payload(jpeg, loc, payload, output)
 
 def get_loc(jpeg):
 


### PR DESCRIPTION
Most likely the payload is already stored somewhere and has special characters.
So I propose to allow reading the payload from a file rather than copy pasting in the shell.

I didn't do it here, but the payload file could be read in binary mode:
the payload decoding step may no longer be necessary?